### PR TITLE
修复：Review等取走日记所有卡的效果，取完后依然显示 prev_c；ChangeMonthAction 限制为ElainaC，避免崩溃

### DIFF
--- a/src/main/java/ElainaMod/action/ChangeMonthAction.java
+++ b/src/main/java/ElainaMod/action/ChangeMonthAction.java
@@ -20,14 +20,14 @@ public class ChangeMonthAction extends AbstractGameAction {
     public ElainaC p;
     public int num;
     boolean isBack;
-    public ChangeMonthAction(AbstractPlayer p, int num, boolean isBack){
-        this.p = (ElainaC) p;
+    public ChangeMonthAction(ElainaC p, int num, boolean isBack){
+        this.p = p;
         this.num = num;
         this.isBack = isBack;
         this.actionType = ActionType.CARD_MANIPULATION;
     }
-    public ChangeMonthAction(AbstractPlayer p, int num){//默认向前
-        this.p = (ElainaC) p;
+    public ChangeMonthAction(ElainaC p, int num){//默认向前
+        this.p = p;
         this.num = num;
         this.isBack = false;
         this.actionType = ActionType.CARD_MANIPULATION;

--- a/src/main/java/ElainaMod/action/TimeGoesBackAction.java
+++ b/src/main/java/ElainaMod/action/TimeGoesBackAction.java
@@ -1,5 +1,6 @@
 package ElainaMod.action;
 
+import ElainaMod.Characters.ElainaC;
 import ElainaMod.cardmods.toInstantCardMod;
 import ElainaMod.cards.AbstractElainaCard;
 import ElainaMod.powers.TimeGoesBackPower;
@@ -46,7 +47,8 @@ public class TimeGoesBackAction extends AbstractGameAction {
             this.p.getRelic("Chemical X").flash();
         }
         if(effect > 0){
-            this.addToBot(new ChangeMonthAction(p,effect,true));
+            if (p instanceof ElainaC)
+                this.addToBot(new ChangeMonthAction((ElainaC) p,effect,true));
         }
 
         if (this.upgraded) {

--- a/src/main/java/ElainaMod/cards/Rush.java
+++ b/src/main/java/ElainaMod/cards/Rush.java
@@ -41,7 +41,8 @@ public class Rush extends AbstractElainaCard {
 
     public void onChoseThisOption() {
         AbstractPlayer p = AbstractDungeon.player;
-        this.addToBot(new ChangeMonthAction(p,this.magicNumber));
+        if (p instanceof ElainaC)
+            this.addToBot(new ChangeMonthAction((ElainaC) p,this.magicNumber));
     }
 
 }

--- a/src/main/java/ElainaMod/orb/ConclusionOrb.java
+++ b/src/main/java/ElainaMod/orb/ConclusionOrb.java
@@ -63,8 +63,9 @@ public class ConclusionOrb extends AbstractOrb {
             c_.current_x = c.current_x;
             c_.current_y = c.current_y;
             c = c_;
-        }else {
+        } else {
             c = null;
+            prev_c = null;
         }
     }
 


### PR DESCRIPTION
先把时令相关的限制在伊蕾娜这里，之后得单独挪出去。